### PR TITLE
[SSO]: Update login logic under CKAN 2.8

### DIFF
--- a/ckanext/ozwillo_pyoidc/conf.py
+++ b/ckanext/ozwillo_pyoidc/conf.py
@@ -33,7 +33,7 @@ CLIENT = {
         "response_type": "code",
         "scope": ["openid", "profile", "email"]
     },
-    "registration_reponse": {
+    "registration_response": {
         "redirect_uris": ["https://opendata.ozwillo-preprod.eu/"]
     },
     "allow": {

--- a/ckanext/ozwillo_pyoidc/oidc.py
+++ b/ckanext/ozwillo_pyoidc/oidc.py
@@ -136,6 +136,9 @@ def create_client(**kwargs):
 
     # The behaviour parameter is not significant for the election process
     _key_set.discard("behaviour")
+    # I do not understand how this was ever working without discarding this
+    # Below is not a case where _key_set includes "registration_response"
+    _key_set.discard("registration_response")
     for param in ["allow"]:
         try:
             setattr(client, param, kwargs[param])

--- a/ckanext/ozwillo_pyoidc/plugin.py
+++ b/ckanext/ozwillo_pyoidc/plugin.py
@@ -106,7 +106,7 @@ class OzwilloPyoidcPlugin(plugins.SingletonPlugin):
 
     def identify(self):
         user = session.get('user')
-        if user and not c.userobj:
+        if user and not getattr(c, 'userobj', None):
             userobj = model.User.get(user)
             c.user = userobj.name
             c.userobj = userobj


### PR DESCRIPTION
In CKAN 2.8 the user views are served by Flask. Flask's redirect_to doesn't trigger a redirection immediately, it just returns a response object that the view function should return. Now, the view function where the login hook is called does nothing with what the plugins return https://github.com/ckan/ckan/blob/master/ckan/views/user.py#L363. To trigger a redirect here our best bet is to override the whole login endpoint from a blueprint in extension, copying the core functionality plus SSO.

Also includes small bugfixes for config